### PR TITLE
-add workflow for automatic documentation generation

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -1,0 +1,26 @@
+name: ci 
+on:
+  push:
+    branches:
+      - master
+permissions:
+  contents: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV 
+      - uses: actions/cache@v3
+        with:
+          key: mkdocs-material-${{ env.cache_id }}
+          path: .cache
+          restore-keys: |
+            mkdocs-material-
+      - run: sudo apt-get -y install doxygen
+      - run: pip install mkdocs-material 
+      - run: pip install mkdoxy
+      - run: mkdocs gh-deploy --force


### PR DESCRIPTION
This workflow automatically generates documentation using mkdocs, which can be used with github pages to host our own generated documentation.

